### PR TITLE
fix(ci): remove invalid actions/setup-powershell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,9 @@ jobs:
           - os: macos-latest
             module_path: ~/.local/share/powershell/Modules
           - os: windows-latest
-            module_path: ~\\Documents\\PowerShell\\Modules
+            module_path: ~\Documents\PowerShell\Modules
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Cache PowerShell modules
         uses: actions/cache@v4
         with:
@@ -53,11 +51,9 @@ jobs:
           - os: macos-latest
             module_path: ~/.local/share/powershell/Modules
           - os: windows-latest
-            module_path: ~\\Documents\\PowerShell\\Modules
+            module_path: ~\Documents\PowerShell\Modules
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Cache PowerShell modules
         uses: actions/cache@v4
         with:
@@ -83,8 +79,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Trust PSGallery and bootstrap
         run: pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
       - name: Install latest PSScriptAnalyzer


### PR DESCRIPTION
Fix CI failures on Sep 14, 2025: all matrix jobs errored with "Unable to resolve action actions/setup-powershell, repository not found" during Setup step. Runners already include pwsh, so drop the invalid step and rely on preinstalled PowerShell.

- Remove actions/setup-powershell from lint/test/latest jobs
- Validated locally: PSScriptAnalyzer clean; Pester tests pass (2/2)

After merge, CI should run and reach lint/test steps normally.