### PR TITLE
release: v0.2.1 – auth workflow hardening + JSON output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
             module_path: ~\\Documents\\PowerShell\\Modules
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Cache PowerShell modules
         uses: actions/cache@v4
         with:
@@ -35,9 +33,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-psmodules-
       - name: Trust PSGallery and bootstrap
-        run: pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          if (Get-Command Set-PSResourceRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSResourceRepository -Name PSGallery -Trusted -ErrorAction SilentlyContinue } catch {}
+          } elseif (Get-Command Set-PSRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue } catch {}
+          }
+          if (Get-Command Install-PackageProvider -ErrorAction SilentlyContinue) {
+            try { Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue | Out-Null } catch {}
+          }
+          exit 0
       - name: Install PSScriptAnalyzer
-        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Run PSScriptAnalyzer
         run: pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse"
 
@@ -56,8 +65,6 @@ jobs:
             module_path: ~\\Documents\\PowerShell\\Modules
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Cache PowerShell modules
         uses: actions/cache@v4
         with:
@@ -66,9 +73,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-psmodules-
       - name: Trust PSGallery and bootstrap
-        run: pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          if (Get-Command Set-PSResourceRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSResourceRepository -Name PSGallery -Trusted -ErrorAction SilentlyContinue } catch {}
+          } elseif (Get-Command Set-PSRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue } catch {}
+          }
+          if (Get-Command Install-PackageProvider -ErrorAction SilentlyContinue) {
+            try { Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue | Out-Null } catch {}
+          }
+          exit 0
       - name: Install Pester
-        run: pwsh -c "Install-Module -Name Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Run Pester tests
         run: pwsh -c "Invoke-Pester -Path tests"
 
@@ -83,14 +101,23 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Trust PSGallery and bootstrap
-        run: pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          if (Get-Command Set-PSResourceRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSResourceRepository -Name PSGallery -Trusted -ErrorAction SilentlyContinue } catch {}
+          } elseif (Get-Command Set-PSRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue } catch {}
+          }
+          if (Get-Command Install-PackageProvider -ErrorAction SilentlyContinue) {
+            try { Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue | Out-Null } catch {}
+          }
+          exit 0
       - name: Install latest PSScriptAnalyzer
-        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Install latest Pester
-        run: pwsh -c "Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Lint with latest
         run: pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse"
       - name: Test with latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - 
 
+## [0.2.1] - 2025-09-14
+- fix: robust auth across NinjaOne module versions (param probing, clearer errors).
+- feat: auto instance fallback for client credentials (tries US/US2/EU/CA/OC).
+- fix: pass scopes as array not comma string.
+- tests: add Pester for auth path + fallback.
+- docs: clarify interactive auth requiring client credentials in some versions; note env vars; region fallback tip.
+
 ## [0.2.0] - 2025-08-19
 - feat: non-interactive UX via `-Organization`, `-Location`, `-NonInteractive`.
 - feat: default to `-Install` when omitted.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NinjaOne Universal Installer
-**Version: 0.2.0**
+**Version: 0.2.1**
 
 A single, self-contained PowerShell script that:
 
@@ -38,6 +38,12 @@ Invoke-WebRequest https://raw.githubusercontent.com/baphomet480/ninjaone-univers
 ninja-universal.ps1 -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECRET>'
 ```
 
+Windows one‑liner (download + run):
+```powershell
+irm https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } | `
+  iex; ninja-universal -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECRET>'
+```
+
 ---
 
 ## Requirements
@@ -67,6 +73,7 @@ ninja-universal.ps1 -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECR
 ./ninja-universal.ps1 -Install -Organization 'Acme Co' -Location 'HQ' -NonInteractive `
   -ClientId 'YOUR_ID' -ClientSecret 'YOUR_SECRET'
 ```
+Tip: When using client credentials you can usually omit `-Region`. The installer will try common instances (US, US2, EU, CA, OC) until it succeeds.
 
 ### Headless or SSH (device code auth)
 ```powershell
@@ -75,6 +82,7 @@ ninja-universal.ps1 -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECR
 Notes:
 - Prints a verification URL and code to enter on another device.
 - If the installed NinjaOne module lacks device-code support, use client credentials instead.
+- Some NinjaOne module versions require a registered API client even for interactive/web auth. If you are prompted for ClientId/ClientSecret during login, set `NINJA_CLIENT_ID` and `NINJA_CLIENT_SECRET` (or pass `-ClientId`/`-ClientSecret`).
 
 ### Direct pipe to PowerShell (optional)
 Linux/macOS:
@@ -83,6 +91,16 @@ curl -H 'Cache-Control: no-cache' -sSL \
   https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 | \
   pwsh -c - -Install -ClientId 'YOUR_ID' -ClientSecret 'YOUR_SECRET'
 ```
+
+JSON output (for CI):
+```bash
+pwsh -File ./ninja-universal.ps1 -Install -ClientId "$NINJA_CLIENT_ID" -ClientSecret "$NINJA_CLIENT_SECRET" -Output Json \
+  | jq .
+```
+
+Environment variables supported:
+- `NINJA_CLIENT_ID`, `NINJA_CLIENT_SECRET`, optional `NINJA_REFRESH_TOKEN`.
+- If set, you can skip the corresponding parameters.
 
 ---
 
@@ -108,6 +126,7 @@ curl -sSL https://raw.githubusercontent.com/baphomet480/ninjaone-universal-insta
 | `-Organization`   | Organization Id or Name (skips interactive pick)                     |         |
 | `-Location`       | Location Id or Name (skips interactive pick)                         |         |
 | `-NonInteractive` | Fail instead of prompting when selection is ambiguous                | `false` |
+| `-Output`         | Output format (`Text`, `Json`)                                       | `Text`  |
 | `-UseDeviceCode`  | Force device code auth; auto-used when no GUI is available           | `false` |
 
 ---
@@ -126,6 +145,7 @@ curl -sSL https://raw.githubusercontent.com/baphomet480/ninjaone-universal-insta
 - Empty organisation list: verify API credentials and region/instance.
 - Insufficient privileges: client needs `management` and `monitoring` scopes.
 - Headless sessions: prefer `-UseDeviceCode` instead of web auth.
+- Interactive login asks for ClientId/ClientSecret: your installed NinjaOne module requires a registered API client for interactive auth. Provide `-ClientId`/`-ClientSecret` or set env vars and rerun.
 
 ---
 

--- a/src/NinjaUniversal/NinjaUniversal.psd1
+++ b/src/NinjaUniversal/NinjaUniversal.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'NinjaUniversal.psm1'
-    ModuleVersion     = '0.2.0'
+    ModuleVersion     = '0.2.1'
     GUID              = '3f2e6a0a-53a7-4c7a-8e22-474d24b5b4e2'
     Author            = 'NinjaOne Community'
     CompanyName       = 'NinjaOne'
@@ -21,4 +21,3 @@
     VariablesToExport = @()
     AliasesToExport   = @()
 }
-

--- a/tests/Auth.Tests.ps1
+++ b/tests/Auth.Tests.ps1
@@ -1,0 +1,40 @@
+Describe 'Get-NinjaAuth (module)' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../src/NinjaUniversal/NinjaUniversal.psd1" -Force
+    }
+
+    Context 'Client credentials' {
+        BeforeEach {
+            $global:__connectArgs = $null
+            InModuleScope NinjaUniversal {
+                Mock -CommandName Connect-NinjaOne -MockWith {
+                    param()
+                    $global:__connectArgs = $PSBoundParameters
+                }
+            }
+        }
+
+        It 'Maps NA to US and returns Mode=Client' {
+            $result = InModuleScope NinjaUniversal { Get-NinjaAuth -Region NA -ClientId 'id' -ClientSecret 'secret' }
+            $result.Mode   | Should -Be 'Client'
+            $result.Region | Should -Be 'US'
+        }
+
+        It 'Auto-falls back to a working instance when first fails' {
+            # Fail for 'us', succeed for 'eu'
+            InModuleScope NinjaUniversal {
+                $script:last = $null
+                Mock -CommandName Connect-NinjaOne -ParameterFilter { $PSBoundParameters['Instance'] -eq 'us' -or $PSBoundParameters['Region'] -eq 'us' -or $PSBoundParameters['Environment'] -eq 'us' } -MockWith {
+                    throw [System.Exception]::new('404 Not Found')
+                }
+                Mock -CommandName Connect-NinjaOne -MockWith {
+                    param()
+                    $script:last = $PSBoundParameters
+                }
+                $res = Get-NinjaAuth -Region US -ClientId 'id' -ClientSecret 'secret'
+                $res.Mode | Should -Be 'Client'
+                $script:last | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}


### PR DESCRIPTION
This release improves the end-to-end user workflow and CI friendliness.

Highlights

- Auth flow hardening
  - Detects Connect-NinjaOne capabilities (Instance/Region/Environment, UseWebAuth, UseClientAuth, DeviceCode variants, RefreshToken).
  - Clean fallbacks with actionable messages instead of cryptic parameter errors.
  - Scopes passed as array to avoid ValidateSet issues across module versions.
- Region instance fallback (client credentials)
  - Tries preferred/alias then rotates through common instances: US, US2, EU, CA, OC.
- JSON output
  - New `-Output Json` for CI; emits version, instance, org/location, type, path, installed flag, timestamp.
- Docs & UX
  - README: Windows one-liner; JSON output example; env vars; note about some module versions requiring client credentials even for web auth.
- Tests & quality
  - Pester: added `Auth.Tests.ps1` for client-cred path and instance fallback.
  - ScriptAnalyzer clean on scripts/module.

Version bumps

- Entry script to 0.2.1
- Module manifest to 0.2.1
- CHANGELOG updated (2025-09-14)

Merge plan

- Squash or rebase-merge; tag `v0.2.1` is already pushed.

Post-merge

- Consider cutting a GitHub Release from tag `v0.2.1` with the CHANGELOG notes.
