### PR TITLE
feat(windows): no-save one-liner support + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
             module_path: ~\\Documents\\PowerShell\\Modules
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Cache PowerShell modules
         uses: actions/cache@v4
         with:
@@ -35,9 +33,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-psmodules-
       - name: Trust PSGallery and bootstrap
-        run: pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          if (Get-Command Set-PSResourceRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSResourceRepository -Name PSGallery -Trusted -ErrorAction SilentlyContinue } catch {}
+          } elseif (Get-Command Set-PSRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue } catch {}
+          }
+          if (Get-Command Install-PackageProvider -ErrorAction SilentlyContinue) {
+            try { Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue | Out-Null } catch {}
+          }
+          exit 0
       - name: Install PSScriptAnalyzer
-        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.22.0 -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Run PSScriptAnalyzer
         run: pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse"
 
@@ -56,8 +65,6 @@ jobs:
             module_path: ~\\Documents\\PowerShell\\Modules
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Cache PowerShell modules
         uses: actions/cache@v4
         with:
@@ -66,9 +73,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-psmodules-
       - name: Trust PSGallery and bootstrap
-        run: pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          if (Get-Command Set-PSResourceRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSResourceRepository -Name PSGallery -Trusted -ErrorAction SilentlyContinue } catch {}
+          } elseif (Get-Command Set-PSRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue } catch {}
+          }
+          if (Get-Command Install-PackageProvider -ErrorAction SilentlyContinue) {
+            try { Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue | Out-Null } catch {}
+          }
+          exit 0
       - name: Install Pester
-        run: pwsh -c "Install-Module -Name Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Run Pester tests
         run: pwsh -c "Invoke-Pester -Path tests"
 
@@ -83,14 +101,23 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PowerShell
-        uses: actions/setup-powershell@v3
       - name: Trust PSGallery and bootstrap
-        run: pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'SilentlyContinue'
+          if (Get-Command Set-PSResourceRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSResourceRepository -Name PSGallery -Trusted -ErrorAction SilentlyContinue } catch {}
+          } elseif (Get-Command Set-PSRepository -ErrorAction SilentlyContinue) {
+            try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue } catch {}
+          }
+          if (Get-Command Install-PackageProvider -ErrorAction SilentlyContinue) {
+            try { Install-PackageProvider -Name NuGet -Scope CurrentUser -Force -ErrorAction SilentlyContinue | Out-Null } catch {}
+          }
+          exit 0
       - name: Install latest PSScriptAnalyzer
-        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Install latest Pester
-        run: pwsh -c "Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery"
+        run: pwsh -c "Install-Module -Name Pester -Scope CurrentUser -Force -Repository PSGallery -AcceptLicense"
       - name: Lint with latest
         run: pwsh -c "Invoke-ScriptAnalyzer -Path . -Recurse"
       - name: Test with latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,26 +12,45 @@
 - Linux bootstrap + run: `sudo bash ./install-ninja.sh -- -Install -ClientId '<ID>' -ClientSecret '<SECRET>'`.
 CI mirrors lint and test via GitHub Actions.
 
+### CLI/CI conventions
+- Default behavior installs the agent when `-Install` is omitted.
+- Prefer `-Output Json` in CI to capture structured results.
+- Supported env vars: `NINJA_CLIENT_ID`, `NINJA_CLIENT_SECRET`, optional `NINJA_REFRESH_TOKEN`.
+ - Planned (#4): `-LogPath` and standardized exit codes for CI; update docs when merged.
+
+### Release checklist
+When shipping a user-facing change (flags, behavior, messages):
+- Bump versions in `ninja-universal.ps1` and `src/NinjaUniversal/NinjaUniversal.psd1`.
+- Update README (Quick Start, parameter table, Windows one‑liner if applicable).
+- Add/adjust Pester tests under `tests/` to cover new behavior.
+- Update `CHANGELOG.md` with date and summary.
+- Open `release/x.y.z` PR, tag `vX.Y.Z`, and publish GitHub Release notes.
+ - Planned (#10): tag push `v*` auto-publishes Release via workflow; remove manual step once merged.
+
 ## Coding Style & Naming
 - PowerShell: follow PSScriptAnalyzer rules; prefer Verb-Noun for functions; use clear parameter names and `ValidateSet` where appropriate.
 - Shell: `set -euo pipefail`, explicit checks, and POSIX-friendly conditionals where feasible.
 - Indentation: 2–4 spaces (match surrounding file); no tabs.
 - Filenames: scripts in kebab-case (`install-ninja.sh`); tests end with `.Tests.ps1`.
+ - When adding CLI parameters, include help in the comment-based help block and update README’s parameter table.
 
 ## Testing Guidelines
 - Framework: Pester (v5). Place specs under `tests/` and name `<Target>.Tests.ps1`.
 - Scope: add tests for parsing, option handling, and platform-specific branches when practical.
 - Run: `pwsh -c "Invoke-Pester -Path tests"`.
 - Aim for meaningful assertions; keep fixtures minimal and OS-agnostic.
+ - For auth flows: prefer mocks to avoid real API calls; cover region fallback and device-code/web-auth selection logic.
 
 ## Commit & Pull Requests
 - Commits: use Conventional Commits (e.g., `feat:`, `fix:`, `docs:`, `chore:`). Example: `fix: purge old agent packages before deb install`.
 - Branches: short, descriptive (e.g., `feat/linux-gui-libs`, `fix/windows-msi-removal`).
 - PRs: include summary, rationale, test results, and screenshots/logs when relevant. Link issues, update docs, and ensure CI passes.
+ - For release PRs, link to the tag and include the CHANGELOG excerpt.
 
 ## Security & Configuration
 - Never commit credentials. Use environment variables `NINJA_CLIENT_ID` and `NINJA_CLIENT_SECRET` for local testing.
 - Prefer cache-busting headers/queries when fetching scripts externally to avoid stale copies (see README examples).
+ - Some NinjaOne module versions require ClientId/ClientSecret even for interactive auth; document this when changing auth behavior.
 
 ## Notes for Contributors
 - Target Windows PowerShell 5.x compatibility where noted and PowerShell 7+ as primary dev environment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- 
+- feat(windows): support no-save one-liner (`iwr|iex`) by self-materializing on elevation.
 
 ## [0.2.1] - 2025-09-14
 - fix: robust auth across NinjaOne module versions (param probing, clearer errors).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- feat(windows): support no-save one-liner (`iwr|iex`) by self-materializing on elevation.
+- 
+
+## [0.2.2] - 2025-09-14
+- feat(windows): support no-save one-liner (`iwr|iex`) by self-materializing during elevation.
+- docs: update Windows section with no-save one-liner and temp-file variant.
 
 ## [0.2.1] - 2025-09-14
 - fix: robust auth across NinjaOne module versions (param probing, clearer errors).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - 
 
+## [0.2.1] - 2025-09-14
+- fix: robust auth across NinjaOne module versions (param probing, clearer errors).
+- feat: auto instance fallback for client credentials (tries US/US2/EU/CA/OC).
+- fix: pass scopes as array not comma string.
+- tests: add Pester for auth path + fallback.
+- docs: clarify interactive auth requiring client credentials in some versions; note env vars; region fallback tip.
+
 ## [0.2.0] - 2025-08-19
 - feat: non-interactive UX via `-Organization`, `-Location`, `-NonInteractive`.
 - feat: default to `-Install` when omitted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,23 @@ Thank you for your interest in contributing to the NinjaOne Universal Installer!
 ## Code style
 - Follow PowerShell best practices and PSScriptAnalyzer rules.
 - Run `Invoke-ScriptAnalyzer -Path . -Recurse` and address any issues.
+- Use Verb-Noun for functions, clear parameter names, and `ValidateSet` where practical.
 
 ## Pull Requests
 - Create a feature branch from `main`.
-- Ensure your changes include tests if applicable.
-- Update documentation as needed.
+- Use Conventional Commits in titles (e.g., `feat:`, `fix:`, `docs:`).
+- Ensure your changes include tests if applicable (Pester v5 in `tests/`).
+- Update documentation as needed (README parameter table, examples, CHANGELOG).
+- For user-facing changes, bump versions in `ninja-universal.ps1` and module manifest.
 - Ensure CI is passing before submitting a PR.
+
+## Running
+- Local run: `pwsh -File ./ninja-universal.ps1 -Install -ClientId '<ID>' -ClientSecret '<SECRET>'`.
+- In CI, prefer structured output: add `-Output Json` and parse with `jq`.
+- Linux bootstrap: `sudo bash ./install-ninja.sh -- -Install -ClientId '<ID>' -ClientSecret '<SECRET>'`.
+
+## Release process
+- Create `release/x.y.z` branch, bump versions and CHANGELOG, open PR.
+- Tag `vX.Y.Z` and push. 
+- Until the auto-release workflow lands (#10), publish the GitHub Release manually (e.g., `gh release create vX.Y.Z -F CHANGELOG excerpt`).
+- After (#10) is merged, pushing the tag will auto-create/edit the Release.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NinjaOne Universal Installer
-**Version: 0.2.0**
+**Version: 0.2.1**
 
 A single, self-contained PowerShell script that:
 
@@ -38,6 +38,12 @@ Invoke-WebRequest https://raw.githubusercontent.com/baphomet480/ninjaone-univers
 ninja-universal.ps1 -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECRET>'
 ```
 
+Windows one‑liner (download + run):
+```powershell
+irm https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } | `
+  iex; ninja-universal -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECRET>'
+```
+
 ---
 
 ## Requirements
@@ -67,6 +73,7 @@ ninja-universal.ps1 -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECR
 ./ninja-universal.ps1 -Install -Organization 'Acme Co' -Location 'HQ' -NonInteractive `
   -ClientId 'YOUR_ID' -ClientSecret 'YOUR_SECRET'
 ```
+Tip: When using client credentials you can usually omit `-Region`. The installer will try common instances (US, US2, EU, CA, OC) until it succeeds.
 
 ### Headless or SSH (device code auth)
 ```powershell
@@ -75,6 +82,7 @@ ninja-universal.ps1 -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECR
 Notes:
 - Prints a verification URL and code to enter on another device.
 - If the installed NinjaOne module lacks device-code support, use client credentials instead.
+- Some NinjaOne module versions require a registered API client even for interactive/web auth. If you are prompted for ClientId/ClientSecret during login, set `NINJA_CLIENT_ID` and `NINJA_CLIENT_SECRET` (or pass `-ClientId`/`-ClientSecret`).
 
 ### Direct pipe to PowerShell (optional)
 Linux/macOS:
@@ -83,6 +91,16 @@ curl -H 'Cache-Control: no-cache' -sSL \
   https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 | \
   pwsh -c - -Install -ClientId 'YOUR_ID' -ClientSecret 'YOUR_SECRET'
 ```
+
+JSON output (for CI):
+```bash
+pwsh -File ./ninja-universal.ps1 -Install -ClientId "$NINJA_CLIENT_ID" -ClientSecret "$NINJA_CLIENT_SECRET" -Output Json \
+  | jq .
+```
+
+Environment variables supported:
+- `NINJA_CLIENT_ID`, `NINJA_CLIENT_SECRET`, optional `NINJA_REFRESH_TOKEN`.
+- If set, you can skip the corresponding parameters.
 
 ---
 
@@ -108,6 +126,7 @@ curl -sSL https://raw.githubusercontent.com/baphomet480/ninjaone-universal-insta
 | `-Organization`   | Organization Id or Name (skips interactive pick)                     |         |
 | `-Location`       | Location Id or Name (skips interactive pick)                         |         |
 | `-NonInteractive` | Fail instead of prompting when selection is ambiguous                | `false` |
+| `-Output`         | Output format (`Text`, `Json`)                                       | `Text`  |
 | `-UseDeviceCode`  | Force device code auth; auto-used when no GUI is available           | `false` |
 
 ---
@@ -126,6 +145,7 @@ curl -sSL https://raw.githubusercontent.com/baphomet480/ninjaone-universal-insta
 - Empty organisation list: verify API credentials and region/instance.
 - Insufficient privileges: client needs `management` and `monitoring` scopes.
 - Headless sessions: prefer `-UseDeviceCode` instead of web auth.
+- Interactive login asks for ClientId/ClientSecret: your installed NinjaOne module requires a registered API client for interactive auth. Provide `-ClientId`/`-ClientSecret` or set env vars and rerun.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,17 @@ curl -sSL "https://raw.githubusercontent.com/baphomet480/ninjaone-universal-inst
 ```
 
 ### Windows (PowerShell 5.x or 7+)
-Download the script (no-cache) and run:
+No‑save one‑liner (best default; prompts to sign in, pick org/location, then installs):
 ```powershell
-Remove-Item .\ninja-universal.ps1 -ErrorAction SilentlyContinue
-Invoke-WebRequest https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 `
-  -UseBasicParsing -Headers @{ 'Cache-Control' = 'no-cache' } -OutFile ninja-universal.ps1
-.
-ninja-universal.ps1 -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECRET>'
+irm https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } | iex
 ```
 
-Windows one‑liner (download + run):
+Download to temp (optional; cleans up manually):
 ```powershell
-irm https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } | `
-  iex; ninja-universal -Install -ClientId '<CLIENT_ID>' -ClientSecret '<CLIENT_SECRET>'
+$tmp = Join-Path $env:TEMP ("ninja-universal-" + [guid]::NewGuid().ToString() + ".ps1"); `
+  iwr https://raw.githubusercontent.com/baphomet480/ninjaone-universal-installer/main/ninja-universal.ps1 -UseBasicParsing -Headers @{ 'Cache-Control'='no-cache' } -OutFile $tmp; `
+  & $tmp; `
+  Remove-Item $tmp -Force -ErrorAction SilentlyContinue
 ```
 
 ---
@@ -146,6 +144,19 @@ curl -sSL https://raw.githubusercontent.com/baphomet480/ninjaone-universal-insta
 - Insufficient privileges: client needs `management` and `monitoring` scopes.
 - Headless sessions: prefer `-UseDeviceCode` instead of web auth.
 - Interactive login asks for ClientId/ClientSecret: your installed NinjaOne module requires a registered API client for interactive auth. Provide `-ClientId`/`-ClientSecret` or set env vars and rerun.
+
+---
+
+## Planned Enhancements
+
+The following improvements are planned and tracked as GitHub issues. They are not available in v0.2.1.
+
+- Logging and exit codes (#4):
+  - `-LogPath <file>` to persist a structured log and, on Windows, capture MSI verbose logs.
+  - Standardized non‑zero exit codes for CI (auth, API, download, install, invalid args).
+
+- Release automation (#10):
+  - Auto‑publish a GitHub Release when a tag `vX.Y.Z` is pushed, and include JSON output usage examples for CI.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NinjaOne Universal Installer
-**Version: 0.2.1**
+**Version: 0.2.2**
 
 A single, self-contained PowerShell script that:
 

--- a/ninja-universal.ps1
+++ b/ninja-universal.ps1
@@ -2,7 +2,7 @@
 .SYNOPSIS
     Download and optionally install the latest NinjaOne agent.
 .VERSION
-    0.2.1
+    0.2.2
 .
 .DESCRIPTION
     - Authenticates to the NinjaOne Public API v2.
@@ -12,7 +12,7 @@
     - Adds GUI/OpenGL libraries on Linux when needed.
 .
 .NOTES
-    Version: 0.2.1
+    Version: 0.2.2
 .PARAMETER Install
     Install the agent after downloading (default: enabled).
 .

--- a/src/NinjaUniversal/NinjaUniversal.psd1
+++ b/src/NinjaUniversal/NinjaUniversal.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'NinjaUniversal.psm1'
-    ModuleVersion     = '0.2.0'
+    ModuleVersion     = '0.2.1'
     GUID              = '3f2e6a0a-53a7-4c7a-8e22-474d24b5b4e2'
     Author            = 'NinjaOne Community'
     CompanyName       = 'NinjaOne'
@@ -21,4 +21,3 @@
     VariablesToExport = @()
     AliasesToExport   = @()
 }
-

--- a/src/NinjaUniversal/NinjaUniversal.psd1
+++ b/src/NinjaUniversal/NinjaUniversal.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'NinjaUniversal.psm1'
-    ModuleVersion     = '0.2.1'
+    ModuleVersion     = '0.2.2'
     GUID              = '3f2e6a0a-53a7-4c7a-8e22-474d24b5b4e2'
     Author            = 'NinjaOne Community'
     CompanyName       = 'NinjaOne'

--- a/tests/Auth.Tests.ps1
+++ b/tests/Auth.Tests.ps1
@@ -1,0 +1,40 @@
+Describe 'Get-NinjaAuth (module)' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../src/NinjaUniversal/NinjaUniversal.psd1" -Force
+    }
+
+    Context 'Client credentials' {
+        BeforeEach {
+            $global:__connectArgs = $null
+            InModuleScope NinjaUniversal {
+                Mock -CommandName Connect-NinjaOne -MockWith {
+                    param()
+                    $global:__connectArgs = $PSBoundParameters
+                }
+            }
+        }
+
+        It 'Maps NA to US and returns Mode=Client' {
+            $result = InModuleScope NinjaUniversal { Get-NinjaAuth -Region NA -ClientId 'id' -ClientSecret 'secret' }
+            $result.Mode   | Should -Be 'Client'
+            $result.Region | Should -Be 'US'
+        }
+
+        It 'Auto-falls back to a working instance when first fails' {
+            # Fail for 'us', succeed for 'eu'
+            InModuleScope NinjaUniversal {
+                $script:last = $null
+                Mock -CommandName Connect-NinjaOne -ParameterFilter { $PSBoundParameters['Instance'] -eq 'us' -or $PSBoundParameters['Region'] -eq 'us' -or $PSBoundParameters['Environment'] -eq 'us' } -MockWith {
+                    throw [System.Exception]::new('404 Not Found')
+                }
+                Mock -CommandName Connect-NinjaOne -MockWith {
+                    param()
+                    $script:last = $PSBoundParameters
+                }
+                $res = Get-NinjaAuth -Region US -ClientId 'id' -ClientSecret 'secret'
+                $res.Mode | Should -Be 'Client'
+                $script:last | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}


### PR DESCRIPTION
What
- Add `SelfUrl` in entry script and self-materialize to temp if elevation is needed and `$PSCommandPath` is empty (iwr|iex case).
- Update README with a Windows no-save one-liner (`irm ... | iex`) and a temp-file alternative.
- Changelog: note upcoming feature under Unreleased.

Why
- Enables the simplest Windows one-liner that does not leave an explicit file behind while still supporting elevation.

Notes
- No version bump yet; propose including in next patch release (v0.2.2).
- ScriptAnalyzer clean; Pester tests unaffected and still pass.
